### PR TITLE
feat: runtime directory

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -7,8 +7,6 @@ go/0kn/cmd/xtrellis/xtrellis
 
 go/trellis/cmd/*/*.log
 go/trellis/cmd/*/*.pprof
-go/trellis/cmd/certificates/*.key
-go/trellis/cmd/certificates/*.pem
 go/trellis/cmd/client/client
 go/trellis/cmd/coordinator/clients.json
 go/trellis/cmd/coordinator/coordinator
@@ -18,7 +16,6 @@ go/trellis/cmd/coordinator/messages.json
 go/trellis/cmd/coordinator/res.json
 go/trellis/cmd/coordinator/res.json.csv
 go/trellis/cmd/coordinator/servers.json
-go/trellis/cmd/experiments/*.list
 go/trellis/cmd/server/server
 go/trellis/cmd/simulation/simulation
 go/trellis/cmd/testnet2/testnet2

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,5 @@
 .env
 .git
-docker/
 
 api/gen
 

--- a/.github/test.yml
+++ b/.github/test.yml
@@ -28,7 +28,7 @@ jobs:
       run: docker build -t trellis-test .
 
     - name: Run Tests
-      run: docker run trellis-test go test ./...
+      run: docker run trellis-test make test
 
     - name: Docker Compose Test
       run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,10 +28,10 @@ jobs:
       run: docker compose --project-directory docker/base/ --profile build build
 
     - name: Run Go Tests for 0kn
-      run: docker run 0kn/trellis:latest go test ./go/0kn/...
+      run: docker run 0kn/trellis:latest make test-go-0kn
 
     - name: Run Go Tests for trellis
-      run: docker run 0kn/trellis:latest go test -skip 'TestMarshalZero|TestKeyExchange' ./go/trellis/...
+      run: docker run 0kn/trellis:latest make test-go-trellis
 
     - name: Docker Compose Test Gateway
       run: |

--- a/Makefile
+++ b/Makefile
@@ -30,10 +30,16 @@ init:
 protobuf:
 	cd api && buf generate
 
-.PHONY: test
-test:
+.PHONY: test-go-0kn
+test-go-0kn:
 	go test ./go/0kn/...
+
+.PHONY: test-go-trellis
+test-go-trellis:
 	go test -skip 'TestMarshalZero|TestKeyExchange' ./go/trellis/...
+
+.PHONY: test
+test: test-go-0kn test-go-trellis
 
 .PHONY: clean
 clean:

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,17 @@
+.PHONY: build
+build: init
+	cd go/trellis/cmd/server      && go build
+	cd go/trellis/cmd/client      && go build
+	cd go/trellis/cmd/coordinator && go build
+	cd go/0kn/cmd/xtrellis        && go build
+
+.PHONY: install
+install: init
+	cd go/trellis/cmd/server      && go install
+	cd go/trellis/cmd/client      && go install
+	cd go/trellis/cmd/coordinator && go install
+	cd go/0kn/cmd/xtrellis        && go install
+
 .PHONY: install-deps-osx
 install-deps-osx:
 	brew install protobuf gmp cmake openssl
@@ -17,13 +31,6 @@ init:
 .PHONY: protobuf
 protobuf:
 	cd api && buf generate
-
-.PHONY: build
-build: init
-	cd go/trellis/cmd/server && go install && go build
-	cd go/trellis/cmd/client && go install && go build
-	cd go/trellis/cmd/coordinator && go install && go build
-	cd go/0kn/cmd/xtrellis && go install && go build
 
 .PHONY: test
 test: build-commands

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,10 @@ build: init
 install: init
 	cd go/0kn/cmd/xtrellis && go install
 
+.PHONY: uninstall
+uninstall:
+	rm -f $(shell go env GOBIN)/xtrellis
+
 .PHONY: install-deps-osx
 install-deps-osx:
 	brew install protobuf gmp cmake openssl
@@ -34,6 +38,9 @@ test: build-commands
 .PHONY: clean
 clean:
 	git clean -X -f
+
+.PHONY: very-clean
+very-clean: clean uninstall
 
 .PHONY: docker-images
 docker-images:

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ protobuf:
 	cd api && buf generate
 
 .PHONY: test
-test: build-commands
+test:
 	go test ./go/0kn/...
 	go test -skip 'TestMarshalZero|TestKeyExchange' ./go/trellis/...
 

--- a/Makefile
+++ b/Makefile
@@ -1,16 +1,10 @@
 .PHONY: build
 build: init
-	cd go/trellis/cmd/server      && go build
-	cd go/trellis/cmd/client      && go build
-	cd go/trellis/cmd/coordinator && go build
-	cd go/0kn/cmd/xtrellis        && go build
+	cd go/0kn/cmd/xtrellis && go build
 
 .PHONY: install
 install: init
-	cd go/trellis/cmd/server      && go install
-	cd go/trellis/cmd/client      && go install
-	cd go/trellis/cmd/coordinator && go install
-	cd go/0kn/cmd/xtrellis        && go install
+	cd go/0kn/cmd/xtrellis && go install
 
 .PHONY: install-deps-osx
 install-deps-osx:

--- a/README.md
+++ b/README.md
@@ -67,10 +67,31 @@ Build:
 make build
 ```
 
-Test:
+### Test
 
 ```sh
 make test
+```
+
+### Run
+
+Typical invocation involves sub processes and various config files within a
+working directory so installation is necessary. The following is an example:
+
+```sh
+# build and install executable(s) to directory `go env GOBIN`
+make install
+
+# optional: set working directory; see Environment Variables
+
+# `xtrellis` should now be in your PATH
+xtrellis --help
+
+# run complete gateway test run by ci
+./scripts/test-gateway-ci.sh
+
+# remove installed executable(s)
+make uninstall
 ```
 
 ### Configure
@@ -92,8 +113,7 @@ make test
 1. Run a coordinated local mix-net with gateway enabled, for example:
 
    ```sh
-   cd go/0kn/cmd/xtrellis
-   ./xtrellis coordinator mixnet --gatewayenable --debug
+   xtrellis coordinator mixnet --gatewayenable --debug
    ```
 
    `CTRL-C` to exit.
@@ -115,9 +135,28 @@ make test
 #### With Docker Compose
 
 ```sh
+cd docker/base
+
 # build and run container for gateway test
-docker compose --profile test-gateway up --build
+docker compose --profile test-gateway up --build --abort-on-container-exit
 
 # remove container
 docker compose --profile test-gateway down
+```
+
+### Local Remote Network Simulator
+
+```sh
+# build docker images
+make docker-images
+
+# run remote network simulator
+./scripts/simulate-remote-network.sh
+
+# optional: ssh into coordinator's container
+cd docker/remote-network-simulation
+./coordinator-ssh.sh
+
+# remove containers
+make docker-clean
 ```

--- a/README.md
+++ b/README.md
@@ -73,6 +73,12 @@ Test:
 make test
 ```
 
+### Configure
+
+#### Environment Variables
+
+- `_0KN_WORKDIR` runtime working directory; default = `~/.0KN`
+
 ### E2E Tests
 
 #### Full Automated Test

--- a/docker/base/Dockerfile
+++ b/docker/base/Dockerfile
@@ -78,24 +78,12 @@ RUN ./go/trellis/crypto/pairing/mcl/scripts/install-deps.sh \
 
 COPY . .
 
-# setup go workspace
-RUN ./scripts/go-workspace-init.sh
-
-# generate code from protocol buffer files
-RUN cd api && buf generate
-
-# build trellis; server, client, coordinator
-RUN true \
-  && cd go/trellis/cmd/server \
-    && go install \
-    && go build \
-  && cd ../client \
-    && go install \
-    && go build \
-  && cd ../coordinator \
-    && go install \
-    && go build
-
-RUN cd go/0kn/cmd/xtrellis \
-  && go install \
-  && go build
+RUN \
+  # go install to /usr/local/bin
+  go env -w GOBIN=/usr/local/bin \
+  # setup go workspace
+  && make init \
+  # generate code from protocol buffer files
+  && make protobuf \
+  # build and install binaries
+  && make install

--- a/docker/remote-network-simulation/Dockerfile
+++ b/docker/remote-network-simulation/Dockerfile
@@ -21,9 +21,6 @@ COPY --chown=${SSHUSER}:${SSHUSER} *.sh /tmp/
 
 # setup trellis expectations for config and binary locations
 RUN mkdir -p /home/${SSHUSER}/go/bin \
-  && ln -s \
-    /src/go/trellis/cmd/server/server \
-   /home/${SSHUSER}/go/bin/ \
   && chown -R ${SSHUSER}:${SSHUSER} /home/${SSHUSER}/go
 
 EXPOSE 22

--- a/docker/remote-network-simulation/Dockerfile
+++ b/docker/remote-network-simulation/Dockerfile
@@ -13,15 +13,8 @@ RUN mkdir /var/run/sshd
 ARG SSHUSER=ec2-user
 RUN useradd -m -U -s /bin/bash ${SSHUSER}
 
-# set permissions for user to exeucte (files are generated there)
+# set permissions for user to execute (files are generated there)
 RUN chown -R ${SSHUSER}:${SSHUSER} /src
-
-# avoid base image rebuild for faster dev
-COPY --chown=${SSHUSER}:${SSHUSER} *.sh /tmp/
-
-# setup trellis expectations for config and binary locations
-RUN mkdir -p /home/${SSHUSER}/go/bin \
-  && chown -R ${SSHUSER}:${SSHUSER} /home/${SSHUSER}/go
 
 EXPOSE 22
 CMD ["/usr/sbin/sshd", "-D"]

--- a/docker/remote-network-simulation/coordinator-run.sh
+++ b/docker/remote-network-simulation/coordinator-run.sh
@@ -2,11 +2,15 @@
 
 set -ex
 
+export _0KN_WORKDIR=~/.0KN
+mkdir -p ${_0KN_WORKDIR}
+cd ${_0KN_WORKDIR} # only required for coordinator
+
 # create hosts file, generate config from it, launch coordinator using it
 
 args='--numservers 3 --numgroups 3 --numusers 10 --groupsize 3 --numlayers 10'
-hostsfile='/src/go/trellis/cmd/experiments/ip.list'
+hostsfile="${_0KN_WORKDIR}/ip.list"
 
 echo -e "server-0\nserver-1\nserver-2" > ${hostsfile}
-cd /src/go/0kn/cmd/xtrellis && xtrellis coordinator config ${args} --hostsfile ${hostsfile}
-cd /src/go/trellis/cmd/coordinator && coordinator ${args} --runtype 2
+xtrellis coordinator config ${args} --hostsfile ${hostsfile}
+coordinator ${args} --runtype 2

--- a/docker/remote-network-simulation/coordinator-run.sh
+++ b/docker/remote-network-simulation/coordinator-run.sh
@@ -4,7 +4,6 @@ set -ex
 
 export _0KN_WORKDIR=~/.0KN
 mkdir -p ${_0KN_WORKDIR}
-cd ${_0KN_WORKDIR} # only required for coordinator
 
 # create hosts file, generate config from it, launch coordinator using it
 
@@ -13,4 +12,4 @@ hostsfile="${_0KN_WORKDIR}/ip.list"
 
 echo -e "server-0\nserver-1\nserver-2" > ${hostsfile}
 xtrellis coordinator config ${args} --hostsfile ${hostsfile}
-coordinator ${args} --runtype 2
+xtrellis coordinator experiment ${args} --networktype 2

--- a/docker/remote-network-simulation/coordinator-run.sh
+++ b/docker/remote-network-simulation/coordinator-run.sh
@@ -8,5 +8,5 @@ args='--numservers 3 --numgroups 3 --numusers 10 --groupsize 3 --numlayers 10'
 hostsfile='/src/go/trellis/cmd/experiments/ip.list'
 
 echo -e "server-0\nserver-1\nserver-2" > ${hostsfile}
-cd /src/go/0kn/cmd/xtrellis && ./xtrellis coordinator config ${args} --hostsfile ${hostsfile}
-cd /src/go/trellis/cmd/coordinator && ./coordinator ${args} --runtype 2
+cd /src/go/0kn/cmd/xtrellis && xtrellis coordinator config ${args} --hostsfile ${hostsfile}
+cd /src/go/trellis/cmd/coordinator && coordinator ${args} --runtype 2

--- a/docker/remote-network-simulation/coordinator-start.sh
+++ b/docker/remote-network-simulation/coordinator-start.sh
@@ -19,7 +19,7 @@ cat ${dir}/lkey.pub > ${dir}/authorized_keys
 chown -R ${SSHUSER}:${SSHUSER} ${dir}
 
 # wait for servers to start, then run a coordinated mix-net experiment
-sleep 3s && su -c '/tmp/coordinator-run.sh' ${SSHUSER}
+sleep 3s && su -c '/src/docker/remote-network-simulation/coordinator-run.sh' ${SSHUSER}
 
 # start ssh daemon, useful for local dev
 /usr/sbin/sshd -D

--- a/docker/remote-network-simulation/docker-compose.yml
+++ b/docker/remote-network-simulation/docker-compose.yml
@@ -40,4 +40,4 @@ services:
       service: server-0
     container_name: coordinator
     hostname: coordinator
-    command: /tmp/coordinator-start.sh
+    command: docker/remote-network-simulation/coordinator-start.sh

--- a/go/0kn/cmd/xtrellis/args.go
+++ b/go/0kn/cmd/xtrellis/args.go
@@ -26,7 +26,7 @@ type ArgsCoordinatorCommon struct {
 	RoundInterval  int    `default:"0" help:"delay (in ms) between mix-net lightning rounds"`
 
 	F           float64 `default:"0"`
-	NetworkType int     `default:"1" help:"0: single process, 1: local separate processes"`
+	NetworkType int     `default:"1" help:"0: single process, 1: local separate processes, 2: remote hosts"`
 	NumUsers    int     `default:"100" help:"also NumMessages"`
 	NumServers  int     `default:"10"`
 	MessageSize int     `default:"1024"`

--- a/go/0kn/cmd/xtrellis/coordinator.go
+++ b/go/0kn/cmd/xtrellis/coordinator.go
@@ -10,8 +10,8 @@ import (
 
 	arg "github.com/alexflint/go-arg"
 
-	"github.com/31333337/bmrng/go/0kn/pkg/utils"
 	"github.com/31333337/bmrng/go/0kn/pkg/gateway"
+	"github.com/31333337/bmrng/go/0kn/pkg/utils"
 	"github.com/31333337/bmrng/go/trellis/config"
 	"github.com/31333337/bmrng/go/trellis/coordinator"
 )
@@ -22,6 +22,9 @@ const (
 
 	// run local network in separate processes on the same machine
 	NETWORK_TYPE_LOCAL
+
+	// run network on remote hosts
+	NETWORK_TYPE_REMOTE
 )
 
 func LaunchCoordinator(args ArgsCoordinator, argParser *arg.Parser) {
@@ -109,6 +112,14 @@ func setupNetwork(args ArgsCoordinator) *coordinator.CoordinatorNetwork {
 			}
 		}
 		net = coordinator.NewLocalNetwork(serverConfigs, groupConfigs, clientConfigs)
+
+	case NETWORK_TYPE_REMOTE: // run on remote hosts
+		clientFile := args.ClientFile
+		if args.NumClientServers == 0 {
+			clientFile = ""
+		}
+		net = coordinator.NewRemoteNetwork(args.ServerFile, args.GroupFile, clientFile)
+		net.SetKill()
 	}
 
 	return net
@@ -116,7 +127,7 @@ func setupNetwork(args ArgsCoordinator) *coordinator.CoordinatorNetwork {
 
 func runExperiment(args ArgsCoordinator) {
 	net := setupNetwork(args)
-	if args.NetworkType == NETWORK_TYPE_LOCAL {
+	if args.NetworkType == NETWORK_TYPE_LOCAL || args.NetworkType == NETWORK_TYPE_REMOTE {
 		defer net.KillAll()
 	}
 

--- a/go/trellis/.gitignore
+++ b/go/trellis/.gitignore
@@ -9,12 +9,9 @@ cmd/coordinator/keys.json
 cmd/coordinator/messages.json
 cmd/coordinator/res.json
 cmd/coordinator/res.json.csv
-cmd/certificates/*.pem
-cmd/certificates/*.key
 coordinator/*.pprof
 coordinator/*.prof
 cmd/*/*.pprof
-cmd/experiments/*.list
 cmd/*/*.log
 errors/*.log
 cmd/testnet2/testnet2

--- a/go/trellis/cmd/certificates/certificate.sh
+++ b/go/trellis/cmd/certificates/certificate.sh
@@ -1,2 +1,0 @@
-openssl ecparam -genkey -name prime256v1 -out key$2.pem
-openssl req -x509 -new -nodes -subj "/CN=$2" -addext "subjectAltName = IP.1:$1" -key key$2.pem -out cert$2.pem -sha256 -days 365

--- a/go/trellis/cmd/coordinator/coordinator.go
+++ b/go/trellis/cmd/coordinator/coordinator.go
@@ -42,7 +42,7 @@ var args struct {
 	ClientFile       string `default:"clients.json"`
 	KeyFile          string `default:"keys.json"`
 	MessageFile      string `default:"messages.json"`
-	Ips              string `default:"../experiments/ip.list"`
+	Ips              string `default:"ip.list"`
 	Notes            string `default:""`
 	OutFile          string `default:"res.json"`
 	NoDummies        bool   `default:"True"`

--- a/go/trellis/config/certificates.go
+++ b/go/trellis/config/certificates.go
@@ -81,7 +81,7 @@ func CreateCertificate(addr string) ([]byte, []byte) {
 
 	for _, c := range cmds {
 		cmd := exec.Command(c[0], c[1:]...)
-		cmd.Dir = "../certificates"
+		cmd.Dir = "certificates"
 		if err := cmd.Run(); err != nil {
 			panic(err)
 		}
@@ -108,7 +108,7 @@ func CreateServerWithCertificate(addr string, id int64, cert, key []byte) *Serve
 }
 
 func GetCertificate(addr string) []byte {
-	cert, err := ioutil.ReadFile(fmt.Sprintf("../certificates/cert%s.pem", addr))
+	cert, err := ioutil.ReadFile(fmt.Sprintf("certificates/cert%s.pem", addr))
 	if err != nil {
 		panic(err)
 	}
@@ -116,7 +116,7 @@ func GetCertificate(addr string) []byte {
 }
 
 func GetCertificateKey(addr string) []byte {
-	key, err := ioutil.ReadFile(fmt.Sprintf("../certificates/key%s.pem", addr))
+	key, err := ioutil.ReadFile(fmt.Sprintf("certificates/key%s.pem", addr))
 	if err != nil {
 		panic(err)
 	}

--- a/go/trellis/config/certificates.go
+++ b/go/trellis/config/certificates.go
@@ -54,12 +54,39 @@ func CreateServerWithExisting(addr string, id int64, servers map[int64]*Server) 
 
 func CreateCertificate(addr string) ([]byte, []byte) {
 	ip := IP(addr)
-	cmd := exec.Command("sh", "../certificates/certificate.sh", ip, addr)
-	cmd.Dir = "../certificates"
-	err := cmd.Run()
-	if err != nil {
-		panic(err)
+
+	cmds := [][]string{
+		{
+			"openssl",
+			"ecparam",
+			"-genkey",
+			"-name",
+			"prime256v1",
+			"-out", fmt.Sprintf("key%s.pem", addr),
+		},
+		{
+			"openssl",
+			"req",
+			"-x509",
+			"-new",
+			"-nodes",
+			"-subj", fmt.Sprintf("/CN=%s", addr),
+			"-addext", fmt.Sprintf("subjectAltName = IP.1:%s", ip),
+			"-key", fmt.Sprintf("key%s.pem", addr),
+			"-out", fmt.Sprintf("cert%s.pem", addr),
+			"-sha256",
+			"-days", "365",
+		},
 	}
+
+	for _, c := range cmds {
+		cmd := exec.Command(c[0], c[1:]...)
+		cmd.Dir = "../certificates"
+		if err := cmd.Run(); err != nil {
+			panic(err)
+		}
+	}
+
 	return GetCertificate(addr), GetCertificateKey(addr)
 }
 

--- a/go/trellis/coordinator/network.go
+++ b/go/trellis/coordinator/network.go
@@ -115,9 +115,9 @@ func NewLocalNetwork(serverConfigs map[int64]*config.Server, groupConfigs map[in
 	if err != nil {
 		panic(err)
 	}
-	// spawn each server process - assume we are in cmd/coordinator
+	// spawn each server process
 	for _, s := range c.ServerConfigs {
-		cmd := exec.Command("server", "../coordinator/servers.json", "../coordinator/groups.json", s.Address)
+		cmd := exec.Command("server", "servers.json", "groups.json", s.Address)
 		cmd.Stderr = os.Stderr
 		cmd.Stdout = os.Stdout
 		err := cmd.Start()
@@ -145,7 +145,7 @@ func NewLocalNetwork(serverConfigs map[int64]*config.Server, groupConfigs map[in
 		}
 		// spawn client processes
 		for _, s := range c.ClientConfigs {
-			cmd := exec.Command("client", "../coordinator/servers.json", "../coordinator/groups.json", "../coordinator/clients.json", s.Address)
+			cmd := exec.Command("client", "servers.json", "groups.json", "clients.json", s.Address)
 			cmd.Stderr = os.Stderr
 			cmd.Stdout = os.Stdout
 			err := cmd.Start()

--- a/go/trellis/coordinator/network.go
+++ b/go/trellis/coordinator/network.go
@@ -117,7 +117,7 @@ func NewLocalNetwork(serverConfigs map[int64]*config.Server, groupConfigs map[in
 	}
 	// spawn each server process - assume we are in cmd/coordinator
 	for _, s := range c.ServerConfigs {
-		cmd := exec.Command("../server/server", "../coordinator/servers.json", "../coordinator/groups.json", s.Address)
+		cmd := exec.Command("server", "../coordinator/servers.json", "../coordinator/groups.json", s.Address)
 		cmd.Stderr = os.Stderr
 		cmd.Stdout = os.Stdout
 		err := cmd.Start()
@@ -145,7 +145,7 @@ func NewLocalNetwork(serverConfigs map[int64]*config.Server, groupConfigs map[in
 		}
 		// spawn client processes
 		for _, s := range c.ClientConfigs {
-			cmd := exec.Command("../client/client", "../coordinator/servers.json", "../coordinator/groups.json", "../coordinator/clients.json", s.Address)
+			cmd := exec.Command("client", "../coordinator/servers.json", "../coordinator/groups.json", "../coordinator/clients.json", s.Address)
 			cmd.Stderr = os.Stderr
 			cmd.Stdout = os.Stdout
 			err := cmd.Start()

--- a/go/trellis/coordinator/network.go
+++ b/go/trellis/coordinator/network.go
@@ -117,7 +117,7 @@ func NewLocalNetwork(serverConfigs map[int64]*config.Server, groupConfigs map[in
 	}
 	// spawn each server process
 	for _, s := range c.ServerConfigs {
-		cmd := exec.Command("server", "servers.json", "groups.json", s.Address)
+		cmd := exec.Command("xtrellis", "server", "--addr", s.Address)
 		cmd.Stderr = os.Stderr
 		cmd.Stdout = os.Stdout
 		err := cmd.Start()
@@ -145,7 +145,7 @@ func NewLocalNetwork(serverConfigs map[int64]*config.Server, groupConfigs map[in
 		}
 		// spawn client processes
 		for _, s := range c.ClientConfigs {
-			cmd := exec.Command("client", "servers.json", "groups.json", "clients.json", s.Address)
+			cmd := exec.Command("xtrellis", "client", "--addr", s.Address)
 			cmd.Stderr = os.Stderr
 			cmd.Stdout = os.Stdout
 			err := cmd.Start()

--- a/go/trellis/coordinator/remote.go
+++ b/go/trellis/coordinator/remote.go
@@ -15,12 +15,16 @@ const ServerProcessName = "server"
 const ClientProcessName = "client"
 const waitTime = 10 * time.Second
 
+// server hosts receive configuration files from coordinator,
+// store them in this directory, then access them later
+const confDir = "/tmp"
+
 func TransferFileToAllServers(servers map[int64]*config.Server, fn string) bool {
 	done := make(chan bool)
 	for _, s := range servers {
 		go func(s *config.Server) {
 			cmd := exec.Command("scp", "-i", "~/.ssh/lkey", "-o", "StrictHostKeyChecking=no", fn,
-				fmt.Sprintf("ec2-user@%s:~/go/bin/%s", config.Host(s.Address), fn))
+				fmt.Sprintf("ec2-user@%s:%s/%s", config.Host(s.Address), confDir, fn))
 			cmd.Stderr = os.Stderr
 			cmd.Stdout = os.Stdout
 			// log.Printf("Running %v", cmd)
@@ -48,7 +52,7 @@ func KillRemoteServers(servers map[int64]*config.Server, processName string) {
 		go func(s *config.Server) {
 			cmd := exec.Command("ssh", "-i", "~/.ssh/lkey", "-o", "StrictHostKeyChecking=no",
 				fmt.Sprintf("ec2-user@%s", config.Host(s.Address)),
-				fmt.Sprintf("pkill %s", processName))
+				fmt.Sprintf("pkill xtrellis"))
 			cmd.Stderr = os.Stderr
 			cmd.Stdout = os.Stdout
 			cmd.Run()
@@ -69,7 +73,7 @@ func StartRemoteServers(servers map[int64]*config.Server, processName, serverFil
 		go func(s *config.Server) {
 			cmd := exec.Command("ssh", "-i", "~/.ssh/lkey", "-o", "StrictHostKeyChecking=no",
 				fmt.Sprintf("ec2-user@%s", config.Host(s.Address)),
-				fmt.Sprintf("%s ~/go/bin/%s ~/go/bin/%s %s", processName, serverFile, groupFile, s.Address))
+				fmt.Sprintf("xtrellis %s --serverfile %s/%s --groupfile %s/%s --addr %s", processName, confDir, serverFile, confDir, groupFile, s.Address))
 			cmd.Stderr = os.Stderr
 			cmd.Stdout = os.Stdout
 			// log.Printf("Running %v", cmd)

--- a/go/trellis/coordinator/remote.go
+++ b/go/trellis/coordinator/remote.go
@@ -69,7 +69,7 @@ func StartRemoteServers(servers map[int64]*config.Server, processName, serverFil
 		go func(s *config.Server) {
 			cmd := exec.Command("ssh", "-i", "~/.ssh/lkey", "-o", "StrictHostKeyChecking=no",
 				fmt.Sprintf("ec2-user@%s", config.Host(s.Address)),
-				fmt.Sprintf("~/go/bin/%s ~/go/bin/%s ~/go/bin/%s %s", processName, serverFile, groupFile, s.Address))
+				fmt.Sprintf("%s ~/go/bin/%s ~/go/bin/%s %s", processName, serverFile, groupFile, s.Address))
 			cmd.Stderr = os.Stderr
 			cmd.Stdout = os.Stdout
 			// log.Printf("Running %v", cmd)

--- a/scripts/test-gateway-ci.sh
+++ b/scripts/test-gateway-ci.sh
@@ -2,7 +2,6 @@
 
 set -ex
 
-cd go/0kn/cmd/xtrellis
 xtrellis \
   coordinator \
   mixnet \
@@ -10,7 +9,6 @@ xtrellis \
   --debug \
   ${@} \
   &
-cd -
 
 xtrellis_pid=$!
 

--- a/scripts/test-gateway-ci.sh
+++ b/scripts/test-gateway-ci.sh
@@ -3,7 +3,7 @@
 set -ex
 
 cd go/0kn/cmd/xtrellis
-./xtrellis \
+xtrellis \
   coordinator \
   mixnet \
   --gatewayenable \


### PR DESCRIPTION
- Establish a run-time directory for xtrellis facilitated by an env var for child procs to inherit without cascading args.
- Default directory is `~/.0KN`.
- The `xtrellis` executable is the only one of concern; for build, install, and exec
- external script `certificate.sh` absorbed into code for simplified installation/distribution with single exe

Future consideration:
- configure trellis-as-a-library with hooks for actions including "_spawn server process_" and "_send server config_" so that aspect may evolve outside the scope of trellis internals, yet could still default to running og trellis as it is