### PR TITLE
feat: private server config

### DIFF
--- a/docker/base/Dockerfile
+++ b/docker/base/Dockerfile
@@ -59,8 +59,13 @@ RUN go install github.com/bufbuild/buf/cmd/buf@${VERSION_BUF} \
 WORKDIR /src
 
 
-# pre-copy/cache go.mod for pre-downloading dependencies
+# pre-copy and cache downloaded go modules and other dependencies
 # and only redownloading them in subsequent builds if they change
+
+# build and install mcl
+COPY go/trellis/crypto/pairing/mcl/scripts ./go/trellis/crypto/pairing/mcl/scripts
+RUN ./go/trellis/crypto/pairing/mcl/scripts/install-deps.sh \
+  && ldconfig
 
 COPY api/go.* ./api/
 COPY go/0kn/go.* ./go/0kn/
@@ -70,11 +75,6 @@ RUN cd api && go mod download && go mod verify
 RUN cd go/0kn && go mod download && go mod verify
 RUN cd go/trellis && go mod download && go mod verify
 
-
-# build and install mcl; use docker build cache
-COPY go/trellis/crypto/pairing/mcl/scripts ./go/trellis/crypto/pairing/mcl/scripts
-RUN ./go/trellis/crypto/pairing/mcl/scripts/install-deps.sh \
-  && ldconfig
 
 COPY . .
 

--- a/docker/remote-network-simulation/coordinator-run.sh
+++ b/docker/remote-network-simulation/coordinator-run.sh
@@ -10,6 +10,6 @@ mkdir -p ${_0KN_WORKDIR}
 args='--numservers 3 --numgroups 3 --numusers 10 --groupsize 3 --numlayers 10'
 hostsfile="${_0KN_WORKDIR}/ip.list"
 
-echo -e "server-0\nserver-1\nserver-2" > ${hostsfile}
+echo -e "server-0:8000\nserver-1:8000\nserver-2:8000" > ${hostsfile}
 xtrellis coordinator config ${args} --hostsfile ${hostsfile}
 xtrellis coordinator experiment ${args} --networktype 2

--- a/docker/remote-network-simulation/coordinator-run.sh
+++ b/docker/remote-network-simulation/coordinator-run.sh
@@ -5,11 +5,18 @@ set -ex
 export _0KN_WORKDIR=~/.0KN
 mkdir -p ${_0KN_WORKDIR}
 
-# create hosts file, generate config from it, launch coordinator using it
-
+# minimal mix-net args
 args='--numservers 3 --numgroups 3 --numusers 10 --groupsize 3 --numlayers 10'
-hostsfile="${_0KN_WORKDIR}/ip.list"
 
+# create hosts file for minimal mix-net
+hostsfile="${_0KN_WORKDIR}/hosts.list"
 echo -e "server-0:8000\nserver-1:8000\nserver-2:8000" > ${hostsfile}
+
+# generate mix-net round config from hosts file, share with each host
 xtrellis coordinator config ${args} --hostsfile ${hostsfile}
+
+# launch coordinated experiment using remote hosts
 xtrellis coordinator experiment ${args} --networktype 2
+
+# test gateway using remote hosts
+cd /src && ./scripts/test-gateway-ci.sh ${args} --networktype 2

--- a/docker/remote-network-simulation/coordinator-start.sh
+++ b/docker/remote-network-simulation/coordinator-start.sh
@@ -19,7 +19,7 @@ cat ${dir}/lkey.pub > ${dir}/authorized_keys
 chown -R ${SSHUSER}:${SSHUSER} ${dir}
 
 # wait for servers to start, then run a coordinated mix-net experiment
-sleep 3s && su -c '/src/docker/remote-network-simulation/coordinator-run.sh' ${SSHUSER}
+sleep 3s && su -c '/src/docker/remote-network-simulation/coordinator-run.sh' ${SSHUSER} &
 
 # start ssh daemon, useful for local dev
 /usr/sbin/sshd -D

--- a/docker/remote-network-simulation/ssh-container.sh
+++ b/docker/remote-network-simulation/ssh-container.sh
@@ -2,7 +2,7 @@
 
 source .env
 
-ip=$(docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' coordinator)
+ip=$(docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' "${1:-coordinator}")
 ssh \
   -o StrictHostKeyChecking=no \
   -o UserKnownHostsFile=/dev/null \

--- a/go/0kn/cmd/xtrellis/args.go
+++ b/go/0kn/cmd/xtrellis/args.go
@@ -51,7 +51,7 @@ type ArgsCoordinatorCommon struct {
 }
 
 type ArgsCoordinatorConfig struct {
-	HostsFile string `default:"hosts.list" help:"file with list of remote hosts"`
+	HostsFile string `default:"hosts.list" help:"file with list of remote hosts; format <hostname or ip>:<port>"`
 }
 
 type ArgsCoordinatorExperiment struct {

--- a/go/0kn/cmd/xtrellis/args.go
+++ b/go/0kn/cmd/xtrellis/args.go
@@ -60,6 +60,13 @@ type ArgsServer struct {
 	ArgsCommon
 
 	Addr string `default:"localhost:8000"`
+
+	Config *ArgsServerConfig `arg:"subcommand:config" help:"generate server configuration"`
+}
+
+type ArgsServerConfig struct {
+	ServerPrivateFile string `default:"server-private.json"`
+	ServerPublicFile  string `default:"server-public.json"`
 }
 
 type ArgsClient struct {

--- a/go/0kn/cmd/xtrellis/args.go
+++ b/go/0kn/cmd/xtrellis/args.go
@@ -59,14 +59,14 @@ type ArgsCoordinatorMixnet struct {
 type ArgsServer struct {
 	ArgsCommon
 
-	Addr string `default:"localhost:8000"`
+	Addr              string `default:"localhost:8000"`
+	ServerPrivateFile string `default:"server-private.json"`
+	ServerPublicFile  string `default:"server-public.json"`
 
 	Config *ArgsServerConfig `arg:"subcommand:config" help:"generate server configuration"`
 }
 
 type ArgsServerConfig struct {
-	ServerPrivateFile string `default:"server-private.json"`
-	ServerPublicFile  string `default:"server-public.json"`
 }
 
 type ArgsClient struct {

--- a/go/0kn/cmd/xtrellis/args.go
+++ b/go/0kn/cmd/xtrellis/args.go
@@ -8,6 +8,10 @@ type ArgsCommon struct {
 	KeyFile     string `default:"keys.json"`
 	MessageFile string `default:"messages.json"`
 	OutFile     string `default:"res.json"`
+
+	// local server config
+	ServerPrivateFile string `default:"servers-private.json"`
+	ServerPublicFile  string `default:"servers-public.json"`
 }
 
 type ArgsCoordinator struct {
@@ -59,9 +63,7 @@ type ArgsCoordinatorMixnet struct {
 type ArgsServer struct {
 	ArgsCommon
 
-	Addr              string `default:"localhost:8000"`
-	ServerPrivateFile string `default:"server-private.json"`
-	ServerPublicFile  string `default:"server-public.json"`
+	Addr string `default:"localhost:8000"`
 
 	Config *ArgsServerConfig `arg:"subcommand:config" help:"generate server configuration"`
 }

--- a/go/0kn/cmd/xtrellis/client.go
+++ b/go/0kn/cmd/xtrellis/client.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"log"
+
+	"github.com/31333337/bmrng/go/trellis/client"
+	"github.com/31333337/bmrng/go/trellis/config"
+	"github.com/31333337/bmrng/go/trellis/errors"
+	"github.com/31333337/bmrng/go/trellis/network"
+)
+
+// from trellis/cmd/client/
+func LaunchClient(args ArgsClient) {
+	serversFile := args.ServerFile
+	groupsFile := args.GroupFile
+	clientsFile := args.ClientFile
+	addr := args.Addr
+	errors.Addr = addr
+
+	log.Printf("Launching client with address %s", addr)
+
+	servers, err := config.UnmarshalServersFromFile(serversFile)
+	if err != nil {
+		log.Fatalf("Could not read servers file %s", serversFile)
+	}
+
+	groups, err := config.UnmarshalGroupsFromFile(groupsFile)
+	if err != nil {
+		log.Fatalf("Could not read group file %s", groupsFile)
+	}
+
+	clients, err := config.UnmarshalServersFromFile(clientsFile)
+	if err != nil {
+		log.Fatalf("Could not read clients file %s", clientsFile)
+	}
+
+	clientRunner := client.NewClientRunner(servers, groups)
+
+	// This fails @ network/rpc_call.go callee.HandleSignedMessageStream
+	/*
+		err = clientRunner.Connect()
+		if err != nil {
+			log.Fatalf("Could not make clients %v", err)
+		}
+	*/
+
+	network.RunServer(nil, clientRunner, clients, addr)
+}

--- a/go/0kn/cmd/xtrellis/coordinator.go
+++ b/go/0kn/cmd/xtrellis/coordinator.go
@@ -73,7 +73,12 @@ func processArgs(args *ArgsCoordinator, argParser *arg.Parser) {
 	}
 
 	if args.BinSize == 0 {
-		args.BinSize = config.BinSize2(args.NumLayers, args.NumServers, args.NumUsers, -args.Overflow)
+		args.BinSize = config.BinSize2(
+			args.NumLayers,
+			args.NumServers,
+			args.NumUsers,
+			-args.Overflow,
+		)
 	}
 
 	if args.LimitSize == 0 {
@@ -98,7 +103,13 @@ func setupNetwork(args ArgsCoordinator) *coordinator.CoordinatorNetwork {
 		net = coordinator.NewInProcessNetwork(args.NumServers, args.NumGroups, args.GroupSize)
 
 	case NETWORK_TYPE_LOCAL: // run in separate process on the same machine
-		serverConfigs, groupConfigs, clientConfigs := coordinator.NewLocalConfig(args.NumServers, args.NumGroups, args.GroupSize, args.NumClientServers, false)
+		serverConfigs, groupConfigs, clientConfigs := coordinator.NewLocalConfig(
+			args.NumServers,
+			args.NumGroups,
+			args.GroupSize,
+			args.NumClientServers,
+			false,
+		)
 		if args.LoadMessages {
 			oldServers, err := config.UnmarshalServersFromFile(args.ServerFile)
 			if err != nil {
@@ -219,7 +230,12 @@ func runMixnet(args ArgsCoordinator) {
 	if args.MessageSize <= int(gateway.GetMaxProtocolSize()) {
 		log.Fatal("Error: MessageSize too small for Gateway packet protocol")
 	}
-	gateway.Init(int64(args.MessageSize), args.GatewayEnable, args.GatewayAddrIn, args.GatewayAddrOut)
+	gateway.Init(
+		int64(args.MessageSize),
+		args.GatewayEnable,
+		args.GatewayAddrIn,
+		args.GatewayAddrOut,
+	)
 
 	// setup network
 	net := setupNetwork(args)
@@ -346,7 +362,11 @@ func runConfigGenerator(args ArgsCoordinator) {
 		ids = append(ids, int64(id))
 		if len(hosts) >= args.NumClientServers+args.NumServers {
 			if id < args.NumServers {
-				servers[int64(id)] = config.CreateServerWithExisting(addr+":8000", int64(id), servers)
+				servers[int64(id)] = config.CreateServerWithExisting(
+					addr+":8000",
+					int64(id),
+					servers,
+				)
 			} else if id < args.NumClientServers+args.NumServers {
 				clients[int64(id-args.NumServers)] = config.CreateServerWithExisting(addr+":8900", int64(id-args.NumServers), servers)
 			}

--- a/go/0kn/cmd/xtrellis/coordinator.go
+++ b/go/0kn/cmd/xtrellis/coordinator.go
@@ -361,11 +361,14 @@ func runMixnet(args ArgsCoordinator) {
 	}
 }
 
+// Note: This is a temporary solution within the evolving context of trellis
+// simulator for servers to generate their own config files and only share
+// the public aspects
 // TODO: client servers
 func runConfigGenerator(args ArgsCoordinator) {
 	hosts := readHostsfile(args.Config.HostsFile)
 
-	// hosts --> servers
+	// hosts --> servers (to match trellis function expectations)
 	remoteServers := make(map[int64]*config.Server)
 	for i, host := range hosts {
 		remoteServers[int64(i)] = &config.Server{

--- a/go/0kn/cmd/xtrellis/coordinator.go
+++ b/go/0kn/cmd/xtrellis/coordinator.go
@@ -110,6 +110,14 @@ func setupNetwork(args ArgsCoordinator) *coordinator.CoordinatorNetwork {
 			args.NumClientServers,
 			false,
 		)
+
+		// copy public server config to private servers file
+		// TODO: improve public/private config generation
+		serverPrivateFile := args.ServerPrivateFile
+		if err := config.MarshalServersToFile(serverPrivateFile, serverConfigs); err != nil {
+			log.Fatalf("Could not write private servers file %s: %v", serverPrivateFile, err)
+		}
+
 		if args.LoadMessages {
 			oldServers, err := config.UnmarshalServersFromFile(args.ServerFile)
 			if err != nil {

--- a/go/0kn/cmd/xtrellis/server.go
+++ b/go/0kn/cmd/xtrellis/server.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"log"
+
+	"github.com/31333337/bmrng/go/trellis/config"
+	"github.com/31333337/bmrng/go/trellis/errors"
+	"github.com/31333337/bmrng/go/trellis/network"
+	"github.com/31333337/bmrng/go/trellis/server"
+)
+
+// from trellis/cmd/server/
+func LaunchServer(args ArgsServer) {
+	serversFile := args.ServerFile
+	groupsFile := args.GroupFile
+	addr := args.Addr
+	errors.Addr = addr
+
+	log.Printf("Launching server with address %s", addr)
+
+	servers, err := config.UnmarshalServersFromFile(serversFile)
+	if err != nil {
+		log.Fatalf("Could not read servers file %s", serversFile)
+	}
+
+	groups, err := config.UnmarshalGroupsFromFile(groupsFile)
+	if err != nil {
+		log.Fatalf("Could not read group file %s", groupsFile)
+	}
+
+	// will start in blocked state
+	h := server.NewHandler()
+	server := server.NewServer(&config.Servers{Servers: servers}, &config.Groups{Groups: groups}, h, addr)
+
+	server.TcpConnections.LaunchAccepts()
+	network.RunServer(h, server, servers, addr)
+	config.Flush()
+}

--- a/go/0kn/cmd/xtrellis/xtrellis.go
+++ b/go/0kn/cmd/xtrellis/xtrellis.go
@@ -8,78 +8,7 @@ import (
 	arg "github.com/alexflint/go-arg"
 
 	"github.com/31333337/bmrng/go/0kn/pkg/utils"
-	"github.com/31333337/bmrng/go/trellis/client"
-	"github.com/31333337/bmrng/go/trellis/config"
-	"github.com/31333337/bmrng/go/trellis/errors"
-	"github.com/31333337/bmrng/go/trellis/network"
-	"github.com/31333337/bmrng/go/trellis/server"
 )
-
-// from cmd/server/server.go
-func LaunchServer(args ArgsServer) {
-	serversFile := args.ServerFile
-	groupsFile := args.GroupFile
-	addr := args.Addr
-	errors.Addr = addr
-
-	log.Printf("Launching server with address %s", addr)
-
-	servers, err := config.UnmarshalServersFromFile(serversFile)
-	if err != nil {
-		log.Fatalf("Could not read servers file %s", serversFile)
-	}
-
-	groups, err := config.UnmarshalGroupsFromFile(groupsFile)
-	if err != nil {
-		log.Fatalf("Could not read group file %s", groupsFile)
-	}
-
-	// will start in blocked state
-	h := server.NewHandler()
-	server := server.NewServer(&config.Servers{Servers: servers}, &config.Groups{Groups: groups}, h, addr)
-
-	server.TcpConnections.LaunchAccepts()
-	network.RunServer(h, server, servers, addr)
-	config.Flush()
-}
-
-// from cmd/client/client.go
-func LaunchClient(args ArgsClient) {
-	serversFile := args.ServerFile
-	groupsFile := args.GroupFile
-	clientsFile := args.ClientFile
-	addr := args.Addr
-	errors.Addr = addr
-
-	log.Printf("Launching client with address %s", addr)
-
-	servers, err := config.UnmarshalServersFromFile(serversFile)
-	if err != nil {
-		log.Fatalf("Could not read servers file %s", serversFile)
-	}
-
-	groups, err := config.UnmarshalGroupsFromFile(groupsFile)
-	if err != nil {
-		log.Fatalf("Could not read group file %s", groupsFile)
-	}
-
-	clients, err := config.UnmarshalServersFromFile(clientsFile)
-	if err != nil {
-		log.Fatalf("Could not read clients file %s", clientsFile)
-	}
-
-	clientRunner := client.NewClientRunner(servers, groups)
-
-	// This fails @ network/rpc_call.go callee.HandleSignedMessageStream
-	/*
-		err = clientRunner.Connect()
-		if err != nil {
-			log.Fatalf("Could not make clients %v", err)
-		}
-	*/
-
-	network.RunServer(nil, clientRunner, clients, addr)
-}
 
 // set the working directory from env var and change to the directory
 func setWorkingDirectory() {

--- a/go/0kn/cmd/xtrellis/xtrellis.go
+++ b/go/0kn/cmd/xtrellis/xtrellis.go
@@ -43,6 +43,10 @@ func setWorkingDirectory() {
 	}
 }
 
+func getWorkingDirectory() string {
+	return os.Getenv("_0KN_WORKDIR")
+}
+
 func main() {
 	var args Args
 	argParser := arg.MustParse(&args)

--- a/go/0kn/internal/conf/conf.go
+++ b/go/0kn/internal/conf/conf.go
@@ -1,0 +1,50 @@
+package conf
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/31333337/bmrng/go/trellis/config"
+	"github.com/31333337/bmrng/go/trellis/network"
+)
+
+// Generates a new server config for the given address and save it to the given files.
+// If the server already exists in the config, it is overwritten.
+func LocalServerConfigSet(addr string, serverPrivateFile string, serverPublicFile string) error {
+	// load private server config, if it exists
+	servers, err := config.UnmarshalServersFromFile(serverPrivateFile)
+	if err != nil {
+		servers = make(map[int64]*config.Server)
+	}
+
+	// find server id by address in config, or get next available id
+	id, _ := network.FindConfig(addr, servers)
+	if id < 0 {
+		id = int64(len(servers))
+	}
+
+	// create a new server config with a self-signed certificate
+	cert, key := config.CreateCertificate(addr)
+	servers[id] = config.CreateServerWithCertificate(addr, id, cert, key)
+
+	// write complete (public and private) server config to file
+	if err := config.MarshalServersToFile(serverPrivateFile, servers); err != nil {
+		return errors.New(
+			fmt.Sprintf("Could not write private server file %s: %v", serverPrivateFile, err),
+		)
+	}
+
+	// save public server config to file without private info
+	for id := range servers {
+		servers[id].PrivateKey = nil
+		servers[id].PrivateIdentity = nil
+		servers[id].SignatureKey = nil
+	}
+	if err := config.MarshalServersToFile(serverPublicFile, servers); err != nil {
+		return errors.New(
+			fmt.Sprintf("Could not write public server file %s: %v", serverPublicFile, err),
+		)
+	}
+
+	return nil
+}

--- a/go/0kn/internal/conf/conf.go
+++ b/go/0kn/internal/conf/conf.go
@@ -36,7 +36,7 @@ func LocalServerConfigSet(addr string, serverPrivateFile string, serverPublicFil
 
 	// save public server config to file without private info
 	for id := range servers {
-		servers[id].PrivateKey = nil
+		// servers[id].PrivateKey = nil // !!! TODO/WIP: client server fails if not public
 		servers[id].PrivateIdentity = nil
 		servers[id].SignatureKey = nil
 	}


### PR DESCRIPTION
part 1 of 2; servers keep the secret part of their config to themselves, share the public with the coordinator, which shares the aggregate back to all participating servers. Covers server part of #17 

part 2: #43. "server clients" in trellis-lingo also need private config and more separation from servers